### PR TITLE
Avoid endless login loop when ip of user changes

### DIFF
--- a/libs/SecurityDecorators.py
+++ b/libs/SecurityDecorators.py
@@ -53,6 +53,8 @@ def authenticated(method):
                 logging.warn("Session hijack attempt from %s?" % (
                     self.request.remote_ip,
                 ))
+                self.session.delete()
+                self.clear_all_cookies()
                 self.redirect(self.application.settings['login_url'])
         else:
             self.redirect(self.application.settings['login_url'])


### PR DESCRIPTION
WARNING: not tested, but I think this caused the redirections unless cookies are deleted